### PR TITLE
Proper error handling

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::fmt;
 use std::vec;
 
 use crate::color;
@@ -6,6 +7,66 @@ use crate::color;
 use ::gif as gif_lib;
 
 pub mod gif;
+
+#[derive(Debug)]
+pub enum DecodeError {
+    Init(Option<Box<dyn error::Error + 'static>>, String),
+    Read(Option<Box<dyn error::Error + 'static>>, String),
+    FrameRead(Option<Box<dyn error::Error + 'static>>, String),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        return match self {
+            Self::Init(_, desc) => {
+                f.write_str(format!("Error initializing decoder: {desc}").as_str())
+            }
+            Self::Read(_, desc) => f.write_str(format!("Error reading data: {desc}").as_str()),
+            Self::FrameRead(_, desc) => {
+                f.write_str(format!("Error reading frame: {desc}").as_str())
+            }
+        };
+    }
+}
+
+impl error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        return match self {
+            Self::Init(src, _) => src.as_ref().map(|e| e.as_ref()),
+            Self::Read(src, _) => src.as_ref().map(|e| e.as_ref()),
+            Self::FrameRead(src, _) => src.as_ref().map(|e| e.as_ref()),
+        };
+    }
+}
+
+#[derive(Debug)]
+pub enum EncodeError {
+    Init(Option<Box<dyn error::Error + 'static>>, String),
+    Write(Option<Box<dyn error::Error + 'static>>, String),
+    FrameWrite(Option<Box<dyn error::Error + 'static>>, String),
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        return match self {
+            Self::Init(_, desc) => f.write_str(format!("Error initializing: {desc}").as_str()),
+            Self::Write(_, desc) => f.write_str(format!("Error write data: {desc}").as_str()),
+            Self::FrameWrite(_, desc) => {
+                f.write_str(format!("Error writing frame: {desc}").as_str())
+            }
+        };
+    }
+}
+
+impl error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        return match self {
+            Self::Init(src, _) => src.as_ref().map(|e| e.as_ref()),
+            Self::Write(src, _) => src.as_ref().map(|e| e.as_ref()),
+            Self::FrameWrite(src, _) => src.as_ref().map(|e| e.as_ref()),
+        };
+    }
+}
 
 pub struct Frame<C>
 where
@@ -54,7 +115,7 @@ where
 {
     type InputColor;
 
-    fn encode(&self, frame: Frame<Self::InputColor>) -> Result<(), String>;
+    fn encode(&self, frame: Frame<Self::InputColor>) -> Result<(), Box<dyn error::Error>>;
 
     fn encode_all(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::vec;
 
 use clap::{arg, command, value_parser, ArgMatches};
@@ -6,7 +7,7 @@ use palette;
 mod codec;
 mod color;
 
-fn main_impl<H, C, L, A, Color>(matches: ArgMatches) -> Result<(), Box<dyn std::error::Error>>
+fn main_impl<H, C, L, A, Color>(matches: ArgMatches) -> Result<(), Box<dyn error::Error>>
 where
     Color: color::Color
         + color::Componentize<H, C, L, A>
@@ -67,7 +68,7 @@ where
     return Ok(());
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = command!()
         .arg(arg!(input_file: <INPUT_FILE> "The path to the input file"))
         .arg(arg!(output_file: <OUTPUT_FILE> "The path to the output file"))


### PR DESCRIPTION
- Use `std::error::Error` implementing objects to actually pass along error types instead of strings