### PR TITLE
Support in memory buffers (and more) for encoding/decoding

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,32 @@
+use std::error;
+use std::fs;
+use std::io;
+use std::io::Read;
+use std::path;
+use std::vec;
+
+pub type Buffer = io::Cursor<vec::Vec<u8>>;
+
+pub struct Data {
+    pub buffer: io::Cursor<vec::Vec<u8>>,
+}
+
+impl Data {
+    pub fn new() -> Self {
+        return Data {
+            buffer: io::Cursor::new(vec::Vec::new()),
+        };
+    }
+    pub fn from_path<P: AsRef<path::Path>>(p: P) -> Result<Self, Box<dyn error::Error>> {
+        let file = fs::File::open(p)?;
+        return Self::from_file(file);
+    }
+
+    pub fn from_file(mut file: fs::File) -> Result<Self, Box<dyn error::Error>> {
+        let mut data = Self::new();
+
+        file.read_to_end(data.buffer.get_mut())?;
+
+        return Ok(data);
+    }
+}

--- a/src/codec/gif.rs
+++ b/src/codec/gif.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::error;
-use std::fs::File;
 use std::io;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -226,6 +225,10 @@ where
         }
 
         return Ok(());
+    }
+
+    pub fn into_inner(self) -> Result<W, io::Error> {
+        return self.encoder.into_inner().into_inner();
     }
 }
 

--- a/src/codec/gif.rs
+++ b/src/codec/gif.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::error;
 use std::fs::File;
+use std::io;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::vec;
@@ -10,33 +11,22 @@ use crate::color;
 
 use palette::FromColor;
 
-pub struct GifDecoder<C> {
+pub struct GifDecoder<R: io::Read, C> {
     phantom: PhantomData<C>,
-    decoder: Rc<RefCell<gif::Decoder<File>>>,
+    decoder: Rc<RefCell<gif::Decoder<R>>>,
     screen: gif_dispose::Screen,
 }
 
-impl<C> GifDecoder<C>
+impl<R, C> GifDecoder<R, C>
 where
+    R: io::Read,
     C: color::Color,
 {
-    pub fn new<P: AsRef<std::path::Path> + std::fmt::Display>(
-        path: P,
-    ) -> Result<Self, Box<dyn error::Error>> {
+    pub fn new(read: R) -> Result<Self, Box<dyn error::Error>> {
         let mut decoder_options = gif::DecodeOptions::new();
         decoder_options.set_color_output(gif::ColorOutput::Indexed);
 
-        let img = match File::open(&path) {
-            Ok(f) => f,
-            Err(e) => {
-                return Err(Box::new(DecodeError::Init(
-                    Some(Box::new(e)),
-                    format!("Could not open {}", path),
-                )));
-            }
-        };
-
-        let decoder = match decoder_options.read_info(img) {
+        let decoder = match decoder_options.read_info(read) {
             Ok(dec) => RefCell::new(dec),
             Err(e) => {
                 return Err(Box::new(DecodeError::Read(
@@ -69,20 +59,22 @@ where
     }
 }
 
-impl<C> IntoIterator for GifDecoder<C>
+impl<C, R> IntoIterator for GifDecoder<R, C>
 where
+    R: io::Read,
     C: color::Color,
 {
     type Item = Frame<C>;
-    type IntoIter = GifDecoderImpl<C>;
+    type IntoIter = GifDecoderImpl<R, C>;
 
     fn into_iter(self) -> Self::IntoIter {
         return GifDecoderImpl { decoder: self };
     }
 }
 
-impl<C> super::Decodable for GifDecoder<C>
+impl<R, C> super::Decodable for GifDecoder<R, C>
 where
+    R: io::Read,
     C: color::Color,
 {
     type OutputColor = C;
@@ -132,12 +124,13 @@ where
     }
 }
 
-pub struct GifDecoderImpl<C> {
-    decoder: GifDecoder<C>,
+pub struct GifDecoderImpl<R: io::Read, C> {
+    decoder: GifDecoder<R, C>,
 }
 
-impl<C> Iterator for GifDecoderImpl<C>
+impl<C, R> Iterator for GifDecoderImpl<R, C>
 where
+    R: io::Read,
     C: color::Color,
 {
     type Item = Frame<C>;
@@ -173,27 +166,20 @@ where
     }
 }
 
-pub struct GifEncoder<C> {
+pub struct GifEncoder<W: io::Write, C> {
     phantom: PhantomData<C>,
-    encoder: RefCell<gif::Encoder<File>>,
+    encoder: RefCell<gif::Encoder<W>>,
     width: u16,
     height: u16,
 }
 
-impl<'a, C> GifEncoder<C>
+impl<'a, W, C> GifEncoder<W, C>
 where
+    W: io::Write,
     C: color::Color,
 {
-    pub fn new<P: AsRef<std::path::Path> + std::fmt::Display>(
-        path: P,
-        (width, height): (u16, u16),
-    ) -> Result<Self, String> {
-        let file = match File::create(&path) {
-            Ok(f) => f,
-            Err(e) => return Err(format!("{}: {}", e.to_string(), path)),
-        };
-
-        let encoder_impl = match gif::Encoder::new(file, width, height, &[]) {
+    pub fn new(w: W, (width, height): (u16, u16)) -> Result<Self, String> {
+        let encoder_impl = match gif::Encoder::new(w, width, height, &[]) {
             Ok(enc) => RefCell::new(enc),
             Err(e) => return Err(e.to_string()),
         };
@@ -243,8 +229,9 @@ where
     }
 }
 
-impl<C> super::Encodable for GifEncoder<C>
+impl<W, C> super::Encodable for GifEncoder<W, C>
 where
+    W: io::Write,
     C: color::Color,
     palette::rgb::Rgb<palette::encoding::Srgb, color::ScalarType>:
         palette::convert::FromColorUnclamped<<C as palette::WithAlpha<color::ScalarType>>::Color>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::fs;
 use std::vec;
 
 use clap::{arg, command, value_parser, ArgMatches};
@@ -33,10 +34,12 @@ where
     }
 
     let src_image_path = matches.get_one::<String>("input_file").unwrap();
+    let src_file = fs::File::open(src_image_path)?;
     // automatically transform to the specified color space
-    let decoder: codec::gif::GifDecoder<Color> = codec::gif::GifDecoder::new(src_image_path)?;
+    let decoder: codec::gif::GifDecoder<fs::File, Color> = codec::gif::GifDecoder::new(src_file)?;
     let dest_image_path = matches.get_one::<String>("output_file").unwrap();
-    let encoder = codec::gif::GifEncoder::new(dest_image_path, decoder.get_dimensions())?;
+    let dest_file = fs::File::create(dest_image_path)?;
+    let encoder = codec::gif::GifEncoder::new(dest_file, decoder.get_dimensions())?;
 
     // TODO: figure out either how to generate colors without knowing the frame count OR figure out
     // how to get the frame count while streaming the decoding process (not decoding everything at

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::vec;
 use clap::{arg, command, value_parser, ArgMatches};
 use palette;
 
+mod buffer;
 mod codec;
 mod color;
 
@@ -34,12 +35,14 @@ where
     }
 
     let src_image_path = matches.get_one::<String>("input_file").unwrap();
-    let src_file = fs::File::open(src_image_path)?;
+    let src_data = buffer::Data::from_path(src_image_path)?;
     // automatically transform to the specified color space
-    let decoder: codec::gif::GifDecoder<fs::File, Color> = codec::gif::GifDecoder::new(src_file)?;
+    let decoder: codec::gif::GifDecoder<buffer::Buffer, Color> =
+        codec::gif::GifDecoder::new(src_data.buffer)?;
+
     let dest_image_path = matches.get_one::<String>("output_file").unwrap();
-    let dest_file = fs::File::create(dest_image_path)?;
-    let encoder = codec::gif::GifEncoder::new(dest_file, decoder.get_dimensions())?;
+    let mut dest_data = buffer::Data::new();
+    let encoder = codec::gif::GifEncoder::new(dest_data.buffer, decoder.get_dimensions())?;
 
     // TODO: figure out either how to generate colors without knowing the frame count OR figure out
     // how to get the frame count while streaming the decoding process (not decoding everything at
@@ -67,6 +70,9 @@ where
             interlaced: frame.interlaced,
         })?;
     }
+
+    dest_data.buffer = encoder.into_inner()?;
+    let _ = fs::write(dest_image_path, dest_data.buffer.get_ref())?;
 
     return Ok(());
 }


### PR DESCRIPTION
- use `std::io::{Read, Write}` as the base for encoding and decoding. This allows a lot of flexibility
- change both reading and writing to use in memory buffers