### PR TITLE
Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,17 +262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif-dispose"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40dfdf5be59e0cbbf77cb7c6a91a18ee6d398b70fc54ad900e2bcba1860cb50"
-dependencies = [
- "gif 0.12.0",
- "imgref",
- "rgb",
-]
-
-[[package]]
 name = "half"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,12 +312,6 @@ dependencies = [
  "rgb",
  "thread_local",
 ]
-
-[[package]]
-name = "imgref"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cf49df1085dcfb171460e4592597b84abe50d900fb83efb6e41b20fefd6c2c"
 
 [[package]]
 name = "jpeg-decoder"
@@ -588,7 +571,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "gif 0.12.0",
- "gif-dispose",
  "image",
  "imagequant",
  "palette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ default-run = "rainbowgif"
 clap = { version = "4.0.26", features = ["cargo"] }
 palette = "0.6.1"
 gif = "0.12.0"
-gif-dispose = "4.0.0"
 image = "0.24.5"
 imagequant = "4.0.4"
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,7 +8,7 @@ use std::vec;
 pub type Buffer = io::Cursor<vec::Vec<u8>>;
 
 pub struct Data {
-    pub buffer: io::Cursor<vec::Vec<u8>>,
+    pub buffer: Buffer,
 }
 
 impl Data {

--- a/src/codec/gif.rs
+++ b/src/codec/gif.rs
@@ -4,10 +4,10 @@ use std::io;
 use std::marker::PhantomData;
 use std::vec;
 
+use palette::FromColor;
+
 use super::{Decodable, DecodeError, EncodeError, Frame, Palette};
 use crate::color;
-
-use palette::FromColor;
 
 pub struct GifDecoder<R: io::Read, C> {
     phantom: PhantomData<C>,

--- a/src/codec/gif.rs
+++ b/src/codec/gif.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::error;
 use std::io;
 use std::marker::PhantomData;
-use std::rc::Rc;
 use std::vec;
 
 use super::{Decodable, DecodeError, EncodeError, Frame, Palette};
@@ -40,10 +39,12 @@ where
         });
     }
 
+    #[allow(dead_code)]
     pub fn get_width(&self) -> u16 {
         return self.decoder.width();
     }
 
+    #[allow(dead_code)]
     pub fn get_height(&self) -> u16 {
         return self.decoder.height();
     }
@@ -168,6 +169,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub struct GifEncoder<W: io::Write, C> {
     phantom: PhantomData<C>,
     encoder: RefCell<gif::Encoder<W>>,
@@ -263,8 +265,10 @@ where
         return self.write(frame);
     }
 
-    // TODO
     fn encode_all(&self, frames: vec::Vec<Frame<C>>) -> Result<(), Box<dyn error::Error>> {
+        for frame in frames {
+            self.write(frame)?;
+        }
         return Ok(());
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,5 +1,4 @@
 use std::error;
-use std::fmt;
 use std::vec;
 
 use crate::{color, error_utils};
@@ -63,6 +62,7 @@ where
         };
     }
 
+    #[allow(dead_code)]
     pub fn into_gif_format(self) -> vec::Vec<u8> {
         return self
             .colors

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,10 +1,10 @@
 use std::error;
 use std::vec;
 
-use crate::{color, error_utils};
-
 use ::gif as gif_lib;
 use palette::FromColor;
+
+use crate::{color, error_utils};
 
 pub mod gif;
 pub mod image;

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -1,7 +1,5 @@
-use std::vec;
-
 use clap::{builder::PossibleValue, ValueEnum};
-use palette::{Clamp, FromColor, Hsla, Hsva, LabHue, Lcha, Mix, RgbHue};
+use palette::{Clamp, FromColor, Hsla, Hsva, LabHue, Lcha, RgbHue};
 
 use crate::commandline;
 

--- a/src/commandline.rs
+++ b/src/commandline.rs
@@ -112,6 +112,7 @@ where
     return gradient_desc.generate(frames_len * loop_count, generator_type);
 }
 
+#[allow(dead_code, unused_variables)]
 pub fn get_gradient_2<C>(
     matches: &clap::ArgMatches,
     colors: vec::Vec<C>,

--- a/src/error_utils.rs
+++ b/src/error_utils.rs
@@ -1,6 +1,7 @@
 macro_rules! define_error {
     ($x:ident, { $($y:ident : $z:literal),* $(,)? }) => {
         #[derive(Debug)]
+        #[allow(dead_code)]
         pub enum $x {
             $(
                 $y(Option<Box<dyn std::error::Error>>, String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,9 @@ use std::cmp;
 use std::error;
 use std::fmt;
 use std::fs;
-use std::vec;
 
 use clap::{arg, command, value_parser, ArgMatches};
 use palette;
-use palette::{Clamp, FromColor, Mix};
 
 // TODO just use library
 mod buffer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,7 @@ use std::fs;
 use clap::{arg, command, value_parser, ArgMatches};
 use palette;
 
-// TODO just use library
-mod buffer;
-mod codec;
-mod color;
-mod commandline;
-mod error_utils;
+use rainbowgif::{buffer, codec, color, commandline};
 
 fn mix_impl<C>(matches: ArgMatches, mix_fn: fn(&C, &C) -> C) -> Result<(), Box<dyn error::Error>>
 where


### PR DESCRIPTION
- use library directly instead of exposing modules within main
- removed unused dep
- address lots of warnings and hints, suppressing as necessary
- reorder use statements to be stdlib, third party, then crate modules